### PR TITLE
use css parser instead of broken regex to extract urls

### DIFF
--- a/crawler4j-core/pom.xml
+++ b/crawler4j-core/pom.xml
@@ -128,6 +128,11 @@
             <version>${cache2k.version}</version>
             <scope>runtime</scope>
         </dependency>
+					<dependency>
+						<groupId>com.helger</groupId>
+						<artifactId>ph-css</artifactId>
+						<version>6.5.0</version>
+					</dependency>
         <!-- Logging API -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/parser/CssUrlExtractVisitor.java
+++ b/crawler4j-core/src/main/java/edu/uci/ics/crawler4j/parser/CssUrlExtractVisitor.java
@@ -1,0 +1,82 @@
+package edu.uci.ics.crawler4j.parser;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.helger.css.decl.CSSDeclaration;
+import com.helger.css.decl.CSSExpressionMemberTermURI;
+import com.helger.css.decl.CSSImportRule;
+import com.helger.css.decl.ICSSTopLevelRule;
+import com.helger.css.decl.visit.DefaultCSSUrlVisitor;
+
+import crawlercommons.filters.basic.BasicURLNormalizer;
+import edu.uci.ics.crawler4j.url.UrlResolver;
+
+public class CssUrlExtractVisitor extends DefaultCSSUrlVisitor {
+	
+	private final String referenceAbsoluteUrl;
+	private final BasicURLNormalizer normalizer;
+	private final Set<String> seedUrls = new LinkedHashSet<>();
+	
+	
+	public CssUrlExtractVisitor(final String referenceAbsoluteUrl, final BasicURLNormalizer normalizer) {
+		this.referenceAbsoluteUrl = referenceAbsoluteUrl;
+		this.normalizer = normalizer;
+	}
+	
+	
+	
+	@Override
+	public void onImport(@Nonnull final CSSImportRule aImportRule) {
+		addSeedUrl(aImportRule.getLocationString());
+	}
+	
+	
+	@Override
+	public void onUrlDeclaration(@Nullable final ICSSTopLevelRule aTopLevelRule,
+			@Nonnull final CSSDeclaration aDeclaration, @Nonnull final CSSExpressionMemberTermURI aURITerm)
+	{
+		addSeedUrl(aURITerm.getURIString());
+	}
+	
+	
+	
+	/**
+	 * @return the added seed url or empty
+	 */
+	protected Optional<String> addSeedUrl(final String url) {
+		if (StringUtils.isBlank(url) || url.startsWith("data:")) {
+			return Optional.empty();
+		}
+		
+		final String seedUrl = toSeedUrl(url);
+		seedUrls.add(seedUrl);
+		return Optional.of(seedUrl);
+	}
+	
+	private String toSeedUrl(final String url) {
+		// Normalization is needed, because the String will be input for URI.create(...).
+		return normalizer.filter(UrlResolver.resolveUrl((referenceAbsoluteUrl == null) ? "" : referenceAbsoluteUrl, url));
+	}
+	
+	
+	
+	public String getReferenceAbsoluteUrl() {
+		return referenceAbsoluteUrl;
+	}
+	
+	public BasicURLNormalizer getNormalizer() {
+		return normalizer;
+	}
+	
+	public Set<String> getSeedUrls() {
+		return Collections.unmodifiableSet(seedUrls);
+	}
+}

--- a/crawler4j-core/src/test/java/edu/uci/ics/crawler4j/tests/parser/CssParseDataTest.java
+++ b/crawler4j-core/src/test/java/edu/uci/ics/crawler4j/tests/parser/CssParseDataTest.java
@@ -33,6 +33,18 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class CssParseDataTest {
 
+	@Test
+	void extractUrlWithParenthesisTest() {
+		final String cssText = TestUtils.getInputStringFrom("/css/parenthesis.css");
+		assertUrlsFound(cssText//
+				// This was previously the result, but is wrong
+//				, "http://www.test.com/path/to/'leaves-medium%20(1920x1280"//
+				// This is what should be the result
+				, "http://www.test.com/path/to/leaves-medium%20(1920x1280).jpg"//
+				, "http://www.test.com/images/other-wallpaper.png"//
+		);
+	}
+	
     /**
      * <p>
      * Remark: no urls should be found.
@@ -60,13 +72,13 @@ public class CssParseDataTest {
     }
 	
 	/**
-	 * REMARK: THE HOST OF AN ABSOLUTE URL SHOULD NOT BE ALTERED.
+	 * Remark: the host of an absolute url should not be altered.
 	 */
 	@Test
 	void extractAbsoluteUrlFromCssTest() {
 		// This css is a subset of: https://fonts.googleapis.com/css?family=Lato|Sanchez:400italic,400|Abhaya+Libre
 		final String cssText = TestUtils.getInputStringFrom("/css/fonts-absolute.css");
-		assertDataUrlsFound(cssText//
+		assertUrlsFound(cssText//
 				// This was previously the result, but is wrong
 //				, "http://www.test.com/s/sanchez/v13/Ycm0sZJORluHnXbIfmxh_zQA.woff2"//
 				// This is what should be the result
@@ -77,7 +89,7 @@ public class CssParseDataTest {
 	@Test
 	void extractRelativeUrlFromCssTest() {
 		final String cssText = TestUtils.getInputStringFrom("/css/fonts-relative.css");
-		assertDataUrlsFound(cssText//
+		assertUrlsFound(cssText//
 				, "http://www.test.com/path/s/sanchez/v13/Ycm0sZJORluHnXbIfmxh_zQA.woff2"//
 		);
 	}
@@ -93,7 +105,7 @@ public class CssParseDataTest {
         Assertions.assertThat(outgoingUrls).isEmpty();
     }
     
-	private void assertDataUrlsFound(final String cssText, final String... urls) {
+	private void assertUrlsFound(final String cssText, final String... urls) {
 		final WebURL webURL = Crawler4jTestUtils.newWebURL("http://www.test.com/path/to/bootstrap.min.css");
 		
 		final CssParseData cssParseData = Crawler4jTestUtils.newCssParseData();

--- a/crawler4j-core/src/test/resources/css/parenthesis.css
+++ b/crawler4j-core/src/test/resources/css/parenthesis.css
@@ -1,0 +1,15 @@
+/* test with
+	parenthesis
+	duplicate urls
+	multiple unique urls
+	a url in comments: url('commentedUrl.jpg')
+*/
+.localWallpapered {
+	background-image: url('leaves-medium (1920x1280).jpg');
+}
+.localWallpaperedAgain {
+	background-image: url('leaves-medium (1920x1280).jpg');
+}
+.localWallpaperedDifferent {
+	background-image: url('/images/other-wallpaper.png');
+}


### PR DESCRIPTION
Fixes https://github.com/rzo1/crawler4j/issues/91

Drop-in replacement for the current css parsing based on a (faulty) regex + added some extra tests.